### PR TITLE
improve vendor autoloading

### DIFF
--- a/bin/zf2rapid.php
+++ b/bin/zf2rapid.php
@@ -16,15 +16,10 @@ use ZF2rapid\Console\Console;
 define('ZF2RAPID_ROOT', __DIR__ . '/..');
 
 // get vendor autoloading
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    // Local install
-    require __DIR__ . '/../vendor/autoload.php';
-} elseif (file_exists(getcwd() . '/vendor/autoload.php')) {
-    // Root project is current working directory
-    require getcwd() . '/vendor/autoload.php';
-} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
-    // Relative to composer install
-    require __DIR__ . '/../../../autoload.php';
+if (file_exists(ZF2RAPID_ROOT . '/vendor/autoload.php')) {
+    require ZF2RAPID_ROOT . '/vendor/autoload.php';
+} elseif (file_exists(ZF2RAPID_ROOT . '/../../../vendor/autoload.php')) {
+    require ZF2RAPID_ROOT . '/../../../vendor/autoload.php';
 } else {
     fwrite(STDERR, "Unable to setup autoloading; aborting\n");
     exit(2);

--- a/bin/zf2rapid.php
+++ b/bin/zf2rapid.php
@@ -16,7 +16,19 @@ use ZF2rapid\Console\Console;
 define('ZF2RAPID_ROOT', __DIR__ . '/..');
 
 // get vendor autoloading
-include ZF2RAPID_ROOT . '/vendor/autoload.php';
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    // Local install
+    require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(getcwd() . '/vendor/autoload.php')) {
+    // Root project is current working directory
+    require getcwd() . '/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    // Relative to composer install
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    fwrite(STDERR, "Unable to setup autoloading; aborting\n");
+    exit(2);
+}
 
 // set locale
 Locale::setDefault('en_US');


### PR DESCRIPTION
after a 'composer global require zf2rapid/zf2rapid' autoloading isn't detected properly. This patch fixes it for the global case. ps. stolen from vendor/bin/class_mapgenerator.php